### PR TITLE
Fix comments in server.cfg so CVars are loaded properly

### DIFF
--- a/server/configs/server.cfg
+++ b/server/configs/server.cfg
@@ -1,3 +1,6 @@
-sv_hostname "My server" // server name
-sv_adminpassword "test" // admin password
-sv_password "test" // server password
+// server name
+sv_hostname "My server"
+// admin password
+sv_adminpassword "test"
+// server password
+sv_password "test"


### PR DESCRIPTION
The current server.cfg file has comments at the end of the line after the CVar values. Because of this they aren't actually parsed by ParseInput in Soldat... The relevant lines are here: https://github.com/Soldat/soldat/blob/ace616aae7f028e5e0adb02b0a042d6ea8383bf2/shared/Command.pas#L414-L433

As you can see the CVar is only parsed if Length(InputArray) is 2. The tokens in the comment at the end of the line are counted so this is not true.

There are a couple other reasonable ways to fix this, I chose this one because it doesn't involve changing any existing behavior.