### PR TITLE
Remove default passwords from server.cfg.

### DIFF
--- a/server/configs/server.cfg
+++ b/server/configs/server.cfg
@@ -1,6 +1,6 @@
 // server name
 sv_hostname "My server"
 // admin password
-sv_adminpassword "test"
+//sv_adminpassword "test"
 // server password
-sv_password "test"
+//sv_password "test"

--- a/server/configs/server.cfg
+++ b/server/configs/server.cfg
@@ -1,6 +1,6 @@
 // server name
 sv_hostname "My server"
-// admin password
+//// admin password
 //sv_adminpassword "test"
-// server password
+//// server password
 //sv_password "test"


### PR DESCRIPTION
My PR #15 introduced default server and admin passwords. This is really a terrible idea for a soldat.smod release, these should be set in a server owner's custom server.cfg instead. A better fix is to just make it more obvious that these lines are commented out.