### PR TITLE
Accept temporary epoch timestamps in zipfile

### DIFF
--- a/create_smod.py
+++ b/create_smod.py
@@ -153,7 +153,7 @@ import zipfile
 import zlib
 
 def create_reprod_zip(filename, files):
-    with zipfile.ZipFile(filename, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=5) as zipf:
+    with zipfile.ZipFile(filename, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=5, strict_timestamps=False) as zipf:
         for (file, arcname) in files:
             zipf.write(file, arcname)
 


### PR DESCRIPTION
During builds in nix, files are created with an epoch timestamp (1970), which is not valid for ZIP under Windows.
Python mirror this and fails, see error below.

However, in that case it is totally fine, as the packaged files [will have their timestamps changed later to 1980](https://github.com/opensoldat/base/blob/5f880cdee5b50168d9d4d79026623b5624af9e40/create_smod.py#L162).

```
       >   File "/build/base/create_smod.py", line 194, in <module>
       >     create_reprod_zip('soldat.smod', sorted(files, key=lambda f: f[1]))
       >     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "/build/base/create_smod.py", line 158, in create_reprod_zip
       >     zipf.write(file, arcname)
       >     ~~~~~~~~~~^^^^^^^^^^^^^^^
       >   File "/nix/store/76lchhz5hhik0j5hjy6lwwn3ik0x54aa-python3-3.14.0/lib/python3.14/zipfile/__init__.py", line 1955, in write
       >     zinfo = ZipInfo.from_file(filename, arcname,
       >                               strict_timestamps=self._strict_timestamps)
       >   File "/nix/store/76lchhz5hhik0j5hjy6lwwn3ik0x54aa-python3-3.14.0/lib/python3.14/zipfile/__init__.py", line 634, in from_file
       >     zinfo = cls(arcname, date_time)
       >   File "/nix/store/76lchhz5hhik0j5hjy6lwwn3ik0x54aa-python3-3.14.0/lib/python3.14/zipfile/__init__.py", line 448, in __init__
       >     raise ValueError('ZIP does not support timestamps before 1980')
       > ValueError: ZIP does not support timestamps before 1980
```